### PR TITLE
Support mandatory deep hash params for JSON and XML output

### DIFF
--- a/lib/Web/API.pm
+++ b/lib/Web/API.pm
@@ -751,8 +751,18 @@ sub map_options {
             if $self->debug;
 
         my @missing_attrs;
-        foreach my $attr (@{ $command->{mandatory} }) {
-            push(@missing_attrs, $attr) unless (exists $options->{$attr});
+        if ($content_type =~ m/xml|json/) {
+            foreach my $attr (@{ $command->{mandatory} }) {
+                my @bits = split /\./, $attr;
+                my $node = $options;
+                push(@missing_attrs, $attr) unless
+                    @bits == grep { ref $node eq "HASH" && exists $node->{$_} && ($node = $node->{$_} // {}) } @bits;
+            }
+        }
+        else {
+            foreach my $attr (@{ $command->{mandatory} }) {
+                push(@missing_attrs, $attr) unless (exists $options->{$attr});
+            }
         }
 
         return { error => 'mandatory attributes for this command missing: '


### PR DESCRIPTION
I don't quite know how to describe this, so I'll just write about my use case.

The [UserVoice API](https://developer.uservoice.com/docs/api/reference/) accepts form-urlencoded or JSON payloads. Some calls (eg [create ticket](https://developer.uservoice.com/docs/api/reference/#_api_v1_tickets_post)) take a "deep" structure, in this case `ticket`. For form-urlencoded the args are eg `ticket[subject]`. For JSON you pass in an actual deep hash structure.

In the case of the "create ticket" call, there's two mandatory parameters inside the `ticket` hash, `subject` and `message`. There's no way to tell `Web::API` that they're mandatory, as it just does a naive toplevel check of the options.

So this patch adds support for that. If the output content type is something that can accept a hash (ie JSON and XML), then a mandatory parameter called `foo.bar` will be interpreted as key `bar` inside hash `foo`. So using the UserVoice "create ticket" call again, it requires at minimum this structure:

``` perl
{
    email => q{...},
    ticket => {
        subject => q{...},
        message => q{...},
    },
}
```

Which we can now declare as:

``` perl
mandatory => [qw(email ticket.subject ticket.message)]
```

I suppose the other possibility might be to make `mandatory` take a hashref instead and then we just have to match up the keys. Its probably safer for the future, but a bit less convenient to use. Thoughts?
