### PR TITLE
Log errors only if ->debug set

### DIFF
--- a/lib/Web/API.pm
+++ b/lib/Web/API.pm
@@ -1153,7 +1153,7 @@ sub format_response {
 
     if ($error) {
         chomp($error);
-        $self->log("ERROR: $error");
+        $self->log("ERROR: $error") if $self->debug;
         $answer->{error} = $error;
     }
 


### PR DESCRIPTION
Common things like 404 errors are always printing to STDOUT.

Alternately, I suggest refactoring logging altogether to (a) use a proper logging module instead of just STDOUT and (b) put the `$self->debug` check in the `sub log` instead so it is always applied. Doing (b) would clean up a lot of line noise elsewhere.

I'd be happy to contribute to both of those with a PR if you agree to the concepts.