### PR TITLE
Grammar correction

### DIFF
--- a/lib/Web/API.pm
+++ b/lib/Web/API.pm
@@ -391,7 +391,7 @@ has 'retry_errors' => (
 
 =head2 retry_times (optional)
 
-get/set amount of times a request will be retried at most
+get/set number of times a request will be retried at most
 
 default: 3
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to Web-API.
We thought you might be interested in it too.

It is better to say "number of ..." rather than "amount of ..." for things which are countable.

    Description: Grammar improvement
    Author: Christopher Hoskin <mans0954@debian.org>
    Last-Update: 2018-01-27
    Bug: 

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libweb-api-perl.git/plain/debian/patches/grammar.patch

Thanks for considering,
  Christopher Hoskin,
  Debian Perl Group
