### PR TITLE
Fix auth type support

### DIFF
--- a/lib/Web/API.pm
+++ b/lib/Web/API.pm
@@ -859,12 +859,12 @@ sub talk {
 
     # handle different auth_types
     for (lc $self->auth_type) {
-        if ('basic') { $uri->userinfo($self->user . ':' . $self->api_key); }
-        elsif ('header') {
+        if (/^basic$/) { $uri->userinfo($self->user . ':' . $self->api_key); }
+        elsif (/^header$/) {
             $self->header->{ $self->auth_header } =
                 sprintf($self->auth_header_token_format, $self->api_key);
         }
-        elsif ('hash_key') {
+        elsif (/^hash_key$/) {
             my $api_key_field = $self->api_key_field;
             if ($self->mapping and not $command->{no_mapping}) {
                 $self->log("mapping api_key_field: " . $self->api_key_field)
@@ -874,7 +874,7 @@ sub talk {
             }
             $options->{$api_key_field} = $self->api_key;
         }
-        elsif ('get_params') {
+        elsif (/^get_params$/) {
             $uri->query_form(
                 $self->mapping->{user}    || 'user'    => $self->user,
                 $self->mapping->{api_key} || 'api_key' => $self->api_key,

--- a/t/auth_type.pl
+++ b/t/auth_type.pl
@@ -1,0 +1,91 @@
+# This is a regression test to cover the auth_type parsing logic.
+
+use strict;
+use warnings;
+use lib 'lib';
+
+use Test::More;
+
+my $SAVED_REQUEST;
+
+# A simple API class with a single method: GET https://myapi/do_something
+package MyAPI {
+  use Mouse;
+  with 'Web::API';
+
+  has '+user_agent' => ( default => sub { 'test' } );
+
+  sub commands { { do_something => { method => 'GET' } } }
+
+  # Intercept and save the request (and don't send it)
+  around 'request' => sub {
+    my ($orig, $self, $request) = @_;
+    $SAVED_REQUEST = $request;
+    return;
+  };
+
+  # Clear the saved request ahead of each API call
+  before 'talk' => sub { $SAVED_REQUEST = undef };
+
+  sub BUILD { shift->live_url('https://myapi') }
+}
+
+subtest 'Auth type basic' => sub {
+  my $api = MyAPI->new(
+    auth_type => 'basic',
+    user      => 'Bonzo',
+    api_key   => 'sausages',
+  );
+  $api->do_something();
+  is $SAVED_REQUEST->uri, 'https://Bonzo:sausages@myapi/do_something',
+    'Auth creds in URL';
+};
+
+subtest 'Auth type header' => sub {
+  my $api = MyAPI->new(
+    auth_type => 'header',
+    api_key   => 'sausages',
+  );
+  $api->do_something();
+  like $SAVED_REQUEST->headers->header('Authorization'), qr/token=sausages/,
+    'Auth header with token';
+};
+
+subtest 'Auth type hash_key' => sub {
+  my $api = MyAPI->new(
+    auth_type => 'hash_key',
+    api_key   => 'sausages'
+  );
+  $api->do_something();
+  is $SAVED_REQUEST->uri, 'https://myapi/do_something?key=sausages',
+    'Auth key in query string';
+};
+
+subtest 'Auth type get_params' => sub {
+  my $api = MyAPI->new(
+    auth_type => 'get_params',
+    user      => 'Bonzo',
+    api_key   => 'sausages',
+    mapping   => {api_key => 'key'},
+  );
+  $api->do_something();
+  is $SAVED_REQUEST->uri, 'https://myapi/do_something?user=Bonzo&key=sausages',
+    'Auth creds in query string';
+};
+
+subtest 'Auth type oauth_params' => sub {
+  my $api = MyAPI->new(
+    auth_type       => 'oauth_params',
+    api_key         => 'sausages',
+    access_token    => 'my_token',
+    access_secret   => 'my_token_secret',
+    consumer_secret => 'my_consumer_secret',
+  );
+  $api->do_something();
+  my @oauth_keys = qw(
+    oauth_consumer_key oauth_nonce oauth_signature oauth_signature_method
+    oauth_timestamp oauth_token oauth_version
+  );
+  like $SAVED_REQUEST->uri, qr/$_/, "Oauth key '$_' in querystring"
+    for @oauth_keys;
+};


### PR DESCRIPTION
Fix auth type parsing logic.

Smartmatch usage was removed in the PR below, but it broke support for any auth type excep 'basic'.
- https://github.com/nupfel/Web-API/pull/32

The `if` conditions that replaced the smart matches are wrong; they are string literals that will always evaluate to true. Instead we need to use regular expression matches.

See also: https://github.com/nupfel/Web-API/issues/31#issuecomment-2326481960